### PR TITLE
add bus_watchdog configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ index c6cdb74..111846d 100644
 @@ -9,7 +9,7 @@
          <param name="usb_port">/dev/ttyUSB0</param>
          <param name="baud_rate">1000000</param>
+         <param name="Bus_Watchdog">500</param> <!-- Range: [0, 2540]ms, Default = 500ms -->
 -        <!-- <param name="use_dummy">true</param> -->
 +        <param name="use_dummy">true</param>
        </hardware>

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -104,11 +104,6 @@ private:
   ControlMode control_mode_{ControlMode::Position};
   bool mode_changed_{false};
   bool use_dummy_{false};
-  constexpr const char* kWatchdogItemName = "Bus_Watchdog";
-  constexpr int kWatchdogRegisterUnitMs = 20;
-  constexpr int kWatchdogMinValue = 0;
-  constexpr int kWatchdogMaxValue = 127;
-  constexpr int kWatchdogDefaultMs = 1000;
 };
 }  // namespace dynamixel_hardware
 

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -68,6 +68,9 @@ public:
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
+  void enable_watchdog();
+
+  DYNAMIXEL_HARDWARE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
   DYNAMIXEL_HARDWARE_PUBLIC

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -104,6 +104,11 @@ private:
   ControlMode control_mode_{ControlMode::Position};
   bool mode_changed_{false};
   bool use_dummy_{false};
+  constexpr const char* kWatchdogItemName = "Bus_Watchdog";
+  constexpr int kWatchdogRegisterUnitMs = 20;
+  constexpr int kWatchdogMinValue = 0;
+  constexpr int kWatchdogMaxValue = 127;
+  constexpr int kWatchdogDefaultMs = 1000;
 };
 }  // namespace dynamixel_hardware
 

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -109,64 +109,7 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   enable_torque(false);
   set_control_mode(ControlMode::ExtendedPosition, true);
   set_joint_params();
-
-  for (size_t i = 0; i < info_.joints.size(); ++i)
-  {
-    const hardware_interface::ComponentInfo& joint = info_.joints[i];
-    const int id = joint_ids_[i];
-    const char* log = nullptr;
-
-    int watchdog_ms = kWatchdogDefaultMs;
-    const auto param_it = joint.parameters.find("bus_watchdog");
-    if (param_it != joint.parameters.end())
-    {
-      watchdog_ms = std::stoi(param_it->second);
-    }
-
-    int watchdog_value = std::clamp(
-      watchdog_ms / kWatchdogRegisterUnitMs,
-      kWatchdogMinValue,
-      kWatchdogMaxValue
-    );
-
-    bool write_ok = dynamixel_workbench_.itemWrite(id, kWatchdogItemName, watchdog_value, &log);
-    if (!write_ok)
-    {
-      RCLCPP_WARN(
-        rclcpp::get_logger(kDynamixelHardware),
-        "Failed to set %s for joint %d (requested: %d ms → reg %d): %s",
-        kWatchdogItemName, id, watchdog_ms, watchdog_value, log
-      );
-    }
-    else
-    {
-      RCLCPP_INFO(
-        rclcpp::get_logger(kDynamixelHardware),
-        "%s configured for joint %d: %d ms (register value: %d)",
-        kWatchdogItemName, id, watchdog_value * kWatchdogRegisterUnitMs, watchdog_value
-      );
-    }
-
-    int32_t read_val = 0;
-    bool read_ok = dynamixel_workbench_.itemRead(id, kWatchdogItemName, &read_val, &log);
-    if (read_ok)
-    {
-      RCLCPP_INFO(
-        rclcpp::get_logger(kDynamixelHardware),
-        "Confirmed %s for joint %d: %d (≈ %d ms)",
-        kWatchdogItemName, id, read_val, read_val * kWatchdogRegisterUnitMs
-      );
-    }
-    else
-    {
-      RCLCPP_WARN(
-        rclcpp::get_logger(kDynamixelHardware),
-        "Could not read back %s for joint %d: %s",
-        kWatchdogItemName, id, log
-      );
-    }
-  }
-
+  enable_watchdog();
   enable_torque(true);
 
   const ControlItem * goal_position =
@@ -241,6 +184,66 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   }
 
   return CallbackReturn::SUCCESS;
+}
+
+void DynamixelHardware::enable_watchdog()
+{
+  for (size_t i = 0; i < info_.joints.size(); ++i)
+  {
+    const hardware_interface::ComponentInfo& joint = info_.joints[i];
+    const int id = joint_ids_[i];
+    const char* log = nullptr;
+
+    int watchdog_ms = kWatchdogDefaultMs;
+    const auto param_it = joint.parameters.find("bus_watchdog");
+    if (param_it != joint.parameters.end())
+    {
+      watchdog_ms = std::stoi(param_it->second);
+    }
+
+    int watchdog_value = std::clamp(
+      watchdog_ms / kWatchdogRegisterUnitMs,
+      kWatchdogMinValue,
+      kWatchdogMaxValue
+    );
+
+    bool write_ok = dynamixel_workbench_.itemWrite(id, kWatchdogItemName, watchdog_value, &log);
+    if (!write_ok)
+    {
+      RCLCPP_WARN(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Failed to set %s for joint %d (requested: %d ms → reg %d): %s",
+        kWatchdogItemName, id, watchdog_ms, watchdog_value, log
+      );
+    }
+    else
+    {
+      RCLCPP_INFO(
+        rclcpp::get_logger(kDynamixelHardware),
+        "%s configured for joint %d: %d ms (register value: %d)",
+        kWatchdogItemName, id, watchdog_value * kWatchdogRegisterUnitMs, watchdog_value
+      );
+    }
+
+    int32_t read_val = 0;
+    bool read_ok = dynamixel_workbench_.itemRead(id, kWatchdogItemName, &read_val, &log);
+    if (read_ok)
+    {
+      RCLCPP_INFO(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Confirmed %s for joint %d: %d (≈ %d ms)",
+        kWatchdogItemName, id, read_val, read_val * kWatchdogRegisterUnitMs
+      );
+    }
+    else
+    {
+      RCLCPP_WARN(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Could not read back %s for joint %d: %s",
+        kWatchdogItemName, id, log
+      );
+    }
+  }
 }
 
 std::vector<hardware_interface::StateInterface> DynamixelHardware::export_state_interfaces()

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -47,6 +47,11 @@ constexpr const char * const kExtraJointParameters[] = {
   "Velocity_P_Gain",
   "Velocity_I_Gain",
 };
+constexpr const char* kWatchdogItemName = "Bus_Watchdog";
+constexpr int kWatchdogRegisterUnitMs = 20;
+constexpr int kWatchdogMinValue = 0;
+constexpr int kWatchdogMaxValue = 127;
+constexpr int kWatchdogDefaultMs = 1000;
 
 CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo & info)
 {

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -190,9 +190,9 @@ void DynamixelHardware::enable_watchdog()
 {
   for (size_t i = 0; i < info_.joints.size(); ++i)
   {
-    const hardware_interface::ComponentInfo& joint = info_.joints[i];
+    const hardware_interface::ComponentInfo & joint = info_.joints[i];
     const int id = joint_ids_[i];
-    const char* log = nullptr;
+    const char * log = nullptr;
 
     int watchdog_ms = kWatchdogDefaultMs;
     const auto param_it = joint.parameters.find("bus_watchdog");

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -47,11 +47,6 @@ constexpr const char * const kExtraJointParameters[] = {
   "Velocity_P_Gain",
   "Velocity_I_Gain",
 };
-constexpr const char* kWatchdogItemName = "Bus_Watchdog";
-constexpr int kWatchdogRegisterUnitMs = 20;
-constexpr int kWatchdogMinValue = 0;
-constexpr int kWatchdogMaxValue = 127;
-constexpr int kWatchdogDefaultMs = 1000;
 
 CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo & info)
 {

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -47,6 +47,11 @@ constexpr const char * const kExtraJointParameters[] = {
   "Velocity_P_Gain",
   "Velocity_I_Gain",
 };
+constexpr const char* kWatchdogItemName = "Bus_Watchdog";
+constexpr int kWatchdogRegisterUnitMs = 20;
+constexpr int kWatchdogMinValue = 0;
+constexpr int kWatchdogMaxValue = 127;
+constexpr int kWatchdogDefaultMs = 1000;
 
 CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo & info)
 {
@@ -104,6 +109,64 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   enable_torque(false);
   set_control_mode(ControlMode::ExtendedPosition, true);
   set_joint_params();
+
+  for (size_t i = 0; i < info_.joints.size(); ++i)
+  {
+    const hardware_interface::ComponentInfo& joint = info_.joints[i];
+    const int id = joint_ids_[i];
+    const char* log = nullptr;
+
+    int watchdog_ms = kWatchdogDefaultMs;
+    const auto param_it = joint.parameters.find("bus_watchdog");
+    if (param_it != joint.parameters.end())
+    {
+      watchdog_ms = std::stoi(param_it->second);
+    }
+
+    int watchdog_value = std::clamp(
+      watchdog_ms / kWatchdogRegisterUnitMs,
+      kWatchdogMinValue,
+      kWatchdogMaxValue
+    );
+
+    bool write_ok = dynamixel_workbench_.itemWrite(id, kWatchdogItemName, watchdog_value, &log);
+    if (!write_ok)
+    {
+      RCLCPP_WARN(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Failed to set %s for joint %d (requested: %d ms → reg %d): %s",
+        kWatchdogItemName, id, watchdog_ms, watchdog_value, log
+      );
+    }
+    else
+    {
+      RCLCPP_INFO(
+        rclcpp::get_logger(kDynamixelHardware),
+        "%s configured for joint %d: %d ms (register value: %d)",
+        kWatchdogItemName, id, watchdog_value * kWatchdogRegisterUnitMs, watchdog_value
+      );
+    }
+
+    int32_t read_val = 0;
+    bool read_ok = dynamixel_workbench_.itemRead(id, kWatchdogItemName, &read_val, &log);
+    if (read_ok)
+    {
+      RCLCPP_INFO(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Confirmed %s for joint %d: %d (≈ %d ms)",
+        kWatchdogItemName, id, read_val, read_val * kWatchdogRegisterUnitMs
+      );
+    }
+    else
+    {
+      RCLCPP_WARN(
+        rclcpp::get_logger(kDynamixelHardware),
+        "Could not read back %s for joint %d: %s",
+        kWatchdogItemName, id, log
+      );
+    }
+  }
+
   enable_torque(true);
 
   const ControlItem * goal_position =


### PR DESCRIPTION
---
name: Pull request
about: Create a request
title: 'feat: add Bus_Watchdog Timer configuration to DynamixelHardware'
labels: enhancement
assignees: João Mendes
---

#### **Overview**

- This pull request introduces the initial implementation of the **Bus_Watchdog Timer** configuration for Dynamixel motors.
- The watchdog allows the actuator to automatically disable torque or stop motion when communication with the controller is lost for a defined period.
- A default timeout of **1 second** is applied when no parameter is provided.  
- This implementation improves system safety and reliability in ROS 2 control environments using the `dynamixel_hardware` plugin.

#### **Use the following settings in the overrides file for docker testing**

Use the following configuration to test this feature in a Docker or `autoproj` environment:

- _overrides.yaml_

  ```yaml
    overrides:
      - dynamixel_hardware:
        branch: feat-add-bus-watchdog
  ```

- _manifest_

  ```yaml
    layout:
    - dynamixel_hardware
  ```

#### **What was added/changed in this update**

- Added support for configuring **Bus_Watchdog** via joint parameters.
- Introduced constants for default and clamped watchdog values.
- Implemented automatic parameter handling when no explicit value is provided (default = 1000 ms).
- Added detailed logging for write/read confirmation of watchdog register setup.

#### **Depends On:**

- N/A

#### **Related Issues:**

- N/A

#### **Notes:**

- The feature has been verified for MX-series and PRO-series Dynamixels supporting the `Bus_Watchdog` control table entry.